### PR TITLE
FIX: Matrix has no .to_array() attribute.

### DIFF
--- a/ClusterEnsembles/ClusterEnsembles.py
+++ b/ClusterEnsembles/ClusterEnsembles.py
@@ -65,7 +65,7 @@ def to_pymetis_format(adj_mat):
         idx_row, idx_col = row.nonzero()
         val = row[idx_row, idx_col]
         adjncy += list(idx_col)
-        eweights += list(val.toarray()[0])
+        eweights += val.tolist()[0]
         xadj.append(len(adjncy))
 
     return xadj, adjncy, eweights


### PR DESCRIPTION
Running the example code for the package results in an error in the .to_pymetis() function:
>> "Matrix has no attribute to_array()"

Unlike some other sparse matrix formats like Compressed Sparse Row (CSR) or Compressed Sparse Column (CSC), List of lists (Lil) format doesn't have a toarray() method - corrected it to convert directly to a list.